### PR TITLE
Add action: workflow-dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 .vscode/settings.json
 .idea
 .venv
+.envrc

--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ Below is a summary of the actions in the library and a short description of what
 | [upload-cdk-source](upload-cdk-source/action.yml) | Create and upload an archive of the CDK source to use during deployment of a Liflig CDK Pipeline | ✅ |
 | [upload-cloud-assembly](upload-cloud-assembly/action.yml) | Create and upload an archive of the CDK source to use during deployment of a Liflig CDK Pipeline | ✅ |
 | [upload-s3-artifact](upload-s3-artifact/action.yml) | Upload a file or directory to S3 | ✅ |
+| [workflow-dispatch](workflow-dispatch/action.yml) | Starts a GitHub Actions workflow through workflow_dispatch | ✅ |
 <!-- ACTION_TABLE_END -->

--- a/workflow-dispatch/action.sh
+++ b/workflow-dispatch/action.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+parse_args() {
+  INPUT_OWNER=""
+  INPUT_REPO=""
+  INPUT_REF=""
+  INPUT_WORKFLOW_ID=""
+  INPUT_SOURCE_TYPE=""
+  INPUT_SOURCE_REPO=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --owner)     INPUT_OWNER="$2"; shift; shift ;;
+      --repo)   INPUT_REPO="$2"; shift; shift ;;
+      --ref)   INPUT_REF="$2"; shift; shift ;;
+      --workflow-id)   INPUT_WORKFLOW_ID="$2"; shift; shift ;;
+      --source-type)   INPUT_SOURCE_TYPE="$2"; shift; shift ;;
+      --source-repo)   INPUT_SOURCE_REPO="$2"; shift; shift ;;
+      *) echo "Unknown option '$1'"; exit 1 ;;
+    esac
+  done
+  if [ "$INPUT_OWNER" = "" ]; then
+    echo "Parameter 'owner' is empty"; exit 1
+  fi
+  if [ "$INPUT_REPO" = "" ]; then
+    echo "Parameter 'repo' is empty"; exit 1
+  fi
+  if [ "$INPUT_REF" = "" ]; then
+    echo "Parameter 'ref' is empty"; exit 1
+  fi
+  if [ "$INPUT_WORKFLOW_ID" = "" ]; then
+    echo "Parameter 'workflow-id' is empty"; exit 1
+  fi
+  if [ "$INPUT_SOURCE_TYPE" = "" ]; then
+    echo "Parameter 'source-type' is empty"; exit 1
+  fi
+  if [ "$INPUT_SOURCE_REPO" = "" ]; then
+    echo "Parameter 'source-repo' is empty"; exit 1
+  fi
+
+  readonly INPUT_OWNER INPUT_REPO INPUT_REF INPUT_WORKFLOW_ID INPUT_SOURCE_TYPE INPUT_SOURCE_REPO
+  export INPUT_OWNER INPUT_REPO INPUT_REF INPUT_WORKFLOW_ID INPUT_SOURCE_TYPE INPUT_SOURCE_REPO
+}
+
+main() {
+  parse_args "$@"
+
+  if [ "$GITHUB_TOKEN" = "" ]; then
+    echo "Env var 'GITHUB_TOKEN' is empty, cannot authenticate to target repo"; exit 1
+  fi
+
+  PAYLOAD=$(
+  cat << EOF
+{
+  "ref": "${INPUT_REF}",
+  "inputs": {
+    "source_type": "${INPUT_SOURCE_TYPE}",
+    "source_repo": "${INPUT_SOURCE_REPO}"
+  }
+}
+EOF
+)
+
+  if curl -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --fail-with-body \
+    "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_ID}/dispatches" \
+    -d "$PAYLOAD"; then
+    echo "Successfully triggered workflow dispatch for workflow '${INPUT_WORKFLOW_ID}' at ${INPUT_OWNER}/${INPUT_REPO}#${INPUT_REF}"
+  else
+    echo "Failed to trigger workflow dispatch for workflow '${INPUT_WORKFLOW_ID}' at ${INPUT_OWNER}/${INPUT_REPO}#${INPUT_REF}."
+    exit 1
+  fi
+  }
+
+main "$@"

--- a/workflow-dispatch/action.yml
+++ b/workflow-dispatch/action.yml
@@ -1,0 +1,41 @@
+name: "workflow-dispatch"
+description: |
+  description: "Starts a GitHub Actions workflow through workflow_dispatch"
+  local: true
+inputs:
+  github-token:
+    description: "The token used for authenticating when sending a workflow_dispatch POST request to the target repository."
+    required: true
+  owner:
+    description: "The owner of the target repository to which the workflow_dispatch POST request will be sent."
+    required: true
+  repo:
+    description: "The name of the target repository to which the workflow_dispatch POST request will be sent."
+    required: true
+  ref:
+    description: "The tag or branch in the target repository containing the workflow file."
+    required: true
+  workflow-id:
+    description: "The id or name of the workflow to trigger in the target repository."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: trigger deployment
+      id: trigger
+      shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_OWNER: ${{ inputs.owner }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_REF: ${{ inputs.ref }}
+        INPUT_WORKFLOW_ID: ${{ inputs.workflow-id }}
+      run: |
+        bash $GITHUB_ACTION_PATH/action.sh \
+          --owner "$INPUT_OWNER" \
+          --repo "$INPUT_REPO" \
+          --ref "$INPUT_REF" \
+          --workflow-id "$INPUT_WORKFLOW_ID" \
+          --source-type "CI" \
+          --source-repo "$GITHUB_REPOSITORY"
+          


### PR DESCRIPTION
Adds a new action: workflow-dispatch

### Context

We need to be able to notify a project (i.e. an IaC project) when a service project has built and uploaded a new artifact, which must in turn be deployed by the IaC project.

This action simplifies notifying the remote project, and adds `source_type` and `source_repo` info to convey which repo invoked the workflow.

### Implementation

This action wraps a POST-request to the specified GitHub repository, starting the specified workflow from the current workflow.

The supported parameters are general, and may be used to invoke random workflows in random repositories.