### PR TITLE
Fix incoming webhook being true on empty string as url

### DIFF
--- a/slack-notify/action.mjs
+++ b/slack-notify/action.mjs
@@ -28,7 +28,7 @@ const body = JSON.stringify({
 if (dryRun) {
   appendFileSync(process.env.GITHUB_OUTPUT, `payload=${body}\n`)
 } else {
-  const useIncomingWebhook = incomingWebhookUrl !== undefined
+  const useIncomingWebhook = Boolean(incomingWebhookUrl) // null, undefined or empty string means false.
   const endpointUrl = useIncomingWebhook ?  incomingWebhookUrl : "https://slack.com/api/chat.postMessage"
   const response = await fetch(endpointUrl, {
     method: "POST",


### PR DESCRIPTION
It seems Github actions sets empty string as default value for inputs.