### PR TITLE
feat(aikido-scan): add action for Aikido scan + Slack notification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -513,3 +513,22 @@ jobs:
           ASSERT_EXPECTED: "inactive"
           ASSERT_GOT: ${{ steps.act-configure-github-deployment-update-state.outputs.deployment-state }}
         run: test "$ASSERT_GOT" = "$ASSERT_EXPECTED"
+      ######################################################
+      #
+      # test: aikido-scan
+      #
+      ######################################################
+      - uses: ./aikido-scan
+        name: act-aikido-scan-missing-required-input-should-fail
+        id: act-aikido-scan-missing-required-input-should-fail
+        continue-on-error: true
+        with:
+          apikey: ""
+          bot-token: "example"
+          channel: "#my-channel"
+      - name: assert-aikido-scan-missing-required-input-should-fail
+        id: assert-aikido-scan-missing-required-input-should-fail
+        env:
+          ASSERT_EXPECTED: "failure"
+          ASSERT_GOT: ${{ steps.act-aikido-scan-missing-required-input-should-fail.outcome }}
+        run: test "$ASSERT_GOT" = "$ASSERT_EXPECTED"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Below is a summary of the actions in the library and a short description of what
 <!-- ACTION_TABLE_START -->
 | Action | Description | Local usage |
 | --- | --- | --- |
+| [aikido-scan](aikido-scan/action.yml) | Run an Aikido release scan and post a summary to Slack if issues are found | ✅ |
 | [check-runtime-dependencies](check-runtime-dependencies/action.yml) | Check if the runtime has the expected dependencies | ❌ |
 | [configure-aws-credentials](configure-aws-credentials/action.yml) | Configure temporary AWS credentials using the GitHub Actions OpenID Connect Provider | ❌ |
 | [configure-github-deployment](configure-github-deployment/action.yml) | Create or update a GitHub deployment | ❌ |

--- a/aikido-scan/action.sh
+++ b/aikido-scan/action.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+parse_args() {
+  INPUT_APIKEY=""
+  INPUT_REPOSITORY=""
+  INPUT_COMMIT_SHA=""
+  INPUT_MIN_SEVERITY_LEVEL=""
+  INPUT_FAIL_ON_SAST_SCAN=""
+  INPUT_FAIL_ON_IAC_SCAN=""
+  INPUT_FAIL_ON_SECRETS_SCAN=""
+  INPUT_FAIL_ON_DEPENDENCY_SCAN=""
+  INPUT_FAIL_ON_MALWARE_SCAN=""
+  INPUT_NO_FAIL=""
+  INPUT_BOT_TOKEN=""
+  INPUT_CHANNEL=""
+  INPUT_SERVER_URL=""
+  INPUT_REPOSITORY_FULL_NAME=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --apikey)                    INPUT_APIKEY="$2"; shift; shift ;;
+      --repository)                INPUT_REPOSITORY="$2"; shift; shift ;;
+      --commit-sha)                INPUT_COMMIT_SHA="$2"; shift; shift ;;
+      --min-severity-level)        INPUT_MIN_SEVERITY_LEVEL="$2"; shift; shift ;;
+      --fail-on-sast-scan)         INPUT_FAIL_ON_SAST_SCAN="$2"; shift; shift ;;
+      --fail-on-iac-scan)          INPUT_FAIL_ON_IAC_SCAN="$2"; shift; shift ;;
+      --fail-on-secrets-scan)      INPUT_FAIL_ON_SECRETS_SCAN="$2"; shift; shift ;;
+      --fail-on-dependency-scan)   INPUT_FAIL_ON_DEPENDENCY_SCAN="$2"; shift; shift ;;
+      --fail-on-malware-scan)      INPUT_FAIL_ON_MALWARE_SCAN="$2"; shift; shift ;;
+      --no-fail)                   INPUT_NO_FAIL="$2"; shift; shift ;;
+      --bot-token)                 INPUT_BOT_TOKEN="$2"; shift; shift ;;
+      --channel)                   INPUT_CHANNEL="$2"; shift; shift ;;
+      --server-url)                INPUT_SERVER_URL="$2"; shift; shift ;;
+      --repository-full-name)      INPUT_REPOSITORY_FULL_NAME="$2"; shift; shift ;;
+      *) echo "Unknown option '$1'"; exit 1 ;;
+    esac
+  done
+  echo "::add-mask::$INPUT_APIKEY"
+  echo "::add-mask::$INPUT_BOT_TOKEN"
+  if [ "$INPUT_APIKEY" = "" ]; then
+    echo "Parameter 'apikey' is empty"; exit 1
+  fi
+  if [ "$INPUT_REPOSITORY" = "" ]; then
+    echo "Parameter 'repository' is empty"; exit 1
+  fi
+  if [ "$INPUT_COMMIT_SHA" = "" ]; then
+    echo "Parameter 'commit-sha' is empty"; exit 1
+  fi
+  if [ "$INPUT_BOT_TOKEN" = "" ]; then
+    echo "Parameter 'bot-token' is empty"; exit 1
+  fi
+  if [ "$INPUT_CHANNEL" = "" ]; then
+    echo "Parameter 'channel' is empty"; exit 1
+  fi
+  readonly INPUT_APIKEY INPUT_REPOSITORY INPUT_COMMIT_SHA INPUT_MIN_SEVERITY_LEVEL \
+    INPUT_FAIL_ON_SAST_SCAN INPUT_FAIL_ON_IAC_SCAN INPUT_FAIL_ON_SECRETS_SCAN \
+    INPUT_FAIL_ON_DEPENDENCY_SCAN INPUT_FAIL_ON_MALWARE_SCAN INPUT_NO_FAIL \
+    INPUT_BOT_TOKEN INPUT_CHANNEL INPUT_SERVER_URL INPUT_REPOSITORY_FULL_NAME
+  export INPUT_APIKEY INPUT_REPOSITORY INPUT_COMMIT_SHA INPUT_MIN_SEVERITY_LEVEL \
+    INPUT_FAIL_ON_SAST_SCAN INPUT_FAIL_ON_IAC_SCAN INPUT_FAIL_ON_SECRETS_SCAN \
+    INPUT_FAIL_ON_DEPENDENCY_SCAN INPUT_FAIL_ON_MALWARE_SCAN INPUT_NO_FAIL \
+    INPUT_BOT_TOKEN INPUT_CHANNEL INPUT_SERVER_URL INPUT_REPOSITORY_FULL_NAME
+}
+
+build_scan_args() {
+  scan_args=("scan-release" "$INPUT_REPOSITORY" "$INPUT_COMMIT_SHA" "--apikey" "$INPUT_APIKEY")
+  if [ "$INPUT_MIN_SEVERITY_LEVEL" != "" ]; then
+    scan_args+=("--minimum-severity-level" "$INPUT_MIN_SEVERITY_LEVEL")
+  fi
+  [ "$INPUT_FAIL_ON_SAST_SCAN" = "true" ] && scan_args+=("--fail-on-sast-scan")
+  [ "$INPUT_FAIL_ON_IAC_SCAN" = "true" ] && scan_args+=("--fail-on-iac-scan")
+  [ "$INPUT_FAIL_ON_SECRETS_SCAN" = "true" ] && scan_args+=("--fail-on-secrets-scan")
+  [ "$INPUT_FAIL_ON_DEPENDENCY_SCAN" = "false" ] && scan_args+=("--no-fail-on-dependency-scan")
+  [ "$INPUT_FAIL_ON_MALWARE_SCAN" = "true" ] && scan_args+=("--fail-on-malware-scan")
+  true
+}
+
+build_slack_payload() {
+  local issues="$1"
+  local diff_url="$2"
+  local short_sha="${INPUT_COMMIT_SHA:0:7}"
+  local commit_url="$INPUT_SERVER_URL/$INPUT_REPOSITORY_FULL_NAME/commit/$INPUT_COMMIT_SHA"
+  slack_payload="$(jq -n \
+    --arg text "Aikido scan on <$commit_url|$INPUT_REPOSITORY ($short_sha)> found *$issues* issues: $diff_url" \
+    '{text: $text}')"
+}
+
+post_to_slack() {
+  if ! curl \
+    --fail \
+    --silent \
+    --show-error \
+    --request POST \
+    --header "Authorization: Bearer $INPUT_BOT_TOKEN" \
+    --header "Content-Type: application/json; charset=utf-8" \
+    --data "$(jq -c --arg channel "$INPUT_CHANNEL" '. + {channel: $channel}' <<< "$slack_payload")" \
+    "https://slack.com/api/chat.postMessage" \
+    -o /tmp/aikido-scan-slack-response.json; then
+    echo "Failed to post message to Slack" >&2
+    exit 1
+  fi
+  if [ "$(jq --raw-output ".ok" /tmp/aikido-scan-slack-response.json)" != "true" ]; then
+    echo "Slack responded with an error: $(jq --raw-output ".error" /tmp/aikido-scan-slack-response.json)" >&2
+    exit 1
+  fi
+}
+
+main() {
+  parse_args "$@"
+  build_scan_args
+
+  log_file="$(mktemp)"
+  set +e
+  aikido-api-client "${scan_args[@]}" 2>&1 | tee "$log_file"
+  scan_exit_code="${PIPESTATUS[0]}"
+  set -e
+
+  issues="$(grep -oP 'Open issues found: \K\d+' "$log_file" || true)"
+  diff_url="$(grep -oP 'Diff url: \K\S+' "$log_file" || true)"
+  issues="${issues:-0}"
+
+  {
+    echo "issues-found=$issues"
+    echo "diff-url=$diff_url"
+    echo "scan-exit-code=$scan_exit_code"
+  } >> "$GITHUB_OUTPUT"
+
+  if [ "$scan_exit_code" != "0" ]; then
+    build_slack_payload "$issues" "$diff_url"
+    post_to_slack
+    {
+      echo "slack-payload<<AIKIDO_SCAN_EOF"
+      echo "$slack_payload"
+      echo "AIKIDO_SCAN_EOF"
+    } >> "$GITHUB_OUTPUT"
+
+    if [ "$INPUT_NO_FAIL" = "true" ]; then
+      echo "Aikido scan found issues (exit code $scan_exit_code), but 'no-fail' is enabled so the action will not fail"
+      exit 0
+    fi
+    exit "$scan_exit_code"
+  fi
+}
+
+main "$@"

--- a/aikido-scan/action.yml
+++ b/aikido-scan/action.yml
@@ -1,0 +1,98 @@
+name: "aikido-scan"
+description: |
+  description: "Run an Aikido release scan and post a summary to Slack if issues are found"
+  local: true
+inputs:
+  apikey:
+    description: "A GitHub Actions secret containing the Aikido API key used to authenticate with the Aikido CI API."
+  min-severity-level:
+    description: |
+      The minimum severity level of an issue that should cause the scan to fail.
+
+      Allowed values: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL'
+    default: "HIGH"
+  fail-on-sast-scan:
+    description: "Whether the scan should fail if new SAST issues are found"
+    default: "true"
+  fail-on-iac-scan:
+    description: "Whether the scan should fail if new infrastructure-as-code issues are found"
+    default: "true"
+  fail-on-secrets-scan:
+    description: "Whether the scan should fail if exposed secrets are found"
+    default: "true"
+  fail-on-dependency-scan:
+    description: "Whether the scan should fail if new dependency vulnerabilities are found"
+    default: "true"
+  fail-on-malware-scan:
+    description: "Whether the scan should fail if malware is found"
+    default: "false"
+  no-fail:
+    description: |
+      Whether the action should avoid failing the job when the scan finds issues.
+
+      When set to 'true', the scan still runs and Slack is still notified if issues are
+      found, but the action itself exits successfully so CI can continue.
+    default: "false"
+  bot-token:
+    description: "A GitHub Actions secret containing a Slack bot user token."
+  channel:
+    description: "The Slack channel to notify when the scan finds issues (either a name '#my-channel' or an ID 'CXXXXXXXXXXX')"
+    required: true
+outputs:
+  issues-found:
+    description: "The number of open issues found by the scan"
+    value: ${{ steps.scan.outputs.issues-found }}
+  diff-url:
+    description: "A URL to view the issues found by the scan in the Aikido dashboard"
+    value: ${{ steps.scan.outputs.diff-url }}
+  scan-exit-code:
+    description: "The exit code returned by the Aikido CI API client"
+    value: ${{ steps.scan.outputs.scan-exit-code }}
+  slack-payload:
+    description: "The JSON payload sent to Slack, if the scan found issues"
+    value: ${{ steps.scan.outputs.slack-payload }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: "24.18.0"
+
+    - name: install Aikido CI API client
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: npm install --global @aikidosec/ci-api-client
+
+    - name: run Aikido scan
+      id: scan
+      shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        INPUT_APIKEY: ${{ inputs.apikey }}
+        INPUT_REPOSITORY: ${{ github.event.repository.name }}
+        INPUT_COMMIT_SHA: ${{ github.sha }}
+        INPUT_MIN_SEVERITY_LEVEL: ${{ inputs.min-severity-level }}
+        INPUT_FAIL_ON_SAST_SCAN: ${{ inputs.fail-on-sast-scan }}
+        INPUT_FAIL_ON_IAC_SCAN: ${{ inputs.fail-on-iac-scan }}
+        INPUT_FAIL_ON_SECRETS_SCAN: ${{ inputs.fail-on-secrets-scan }}
+        INPUT_FAIL_ON_DEPENDENCY_SCAN: ${{ inputs.fail-on-dependency-scan }}
+        INPUT_FAIL_ON_MALWARE_SCAN: ${{ inputs.fail-on-malware-scan }}
+        INPUT_NO_FAIL: ${{ inputs.no-fail }}
+        INPUT_BOT_TOKEN: ${{ inputs.bot-token }}
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_SERVER_URL: ${{ github.server_url }}
+        INPUT_REPOSITORY_FULL_NAME: ${{ github.repository }}
+      run: |
+        bash "$GITHUB_ACTION_PATH/action.sh" \
+          --apikey "$INPUT_APIKEY" \
+          --repository "$INPUT_REPOSITORY" \
+          --commit-sha "$INPUT_COMMIT_SHA" \
+          --min-severity-level "$INPUT_MIN_SEVERITY_LEVEL" \
+          --fail-on-sast-scan "$INPUT_FAIL_ON_SAST_SCAN" \
+          --fail-on-iac-scan "$INPUT_FAIL_ON_IAC_SCAN" \
+          --fail-on-secrets-scan "$INPUT_FAIL_ON_SECRETS_SCAN" \
+          --fail-on-dependency-scan "$INPUT_FAIL_ON_DEPENDENCY_SCAN" \
+          --fail-on-malware-scan "$INPUT_FAIL_ON_MALWARE_SCAN" \
+          --no-fail "$INPUT_NO_FAIL" \
+          --bot-token "$INPUT_BOT_TOKEN" \
+          --channel "$INPUT_CHANNEL" \
+          --server-url "$INPUT_SERVER_URL" \
+          --repository-full-name "$INPUT_REPOSITORY_FULL_NAME"


### PR DESCRIPTION
Adds a reusable action for Aikido scan and Slack notification. 
_This action will first be tested in Infra repos before it is iterated and deployed in product team context._                                                                                                   
                                                                                                                                              
  - Runs an Aikido release scan against the current repository and commit via @aikidosec/ci-api-client                                        
  - Lets callers override which scan types can fail the build (SAST, IaC, secrets, dependency, malware) and the minimum severity level                                                                                                      
  - Posts to a caller-provided Slack channel, only when the scan finds issues     
  - Supports a _no-fail_ input so CI can continue even when the scan finds issues, instead of always hard-failing the job                     
                                                                                                              
