### PR TITLE
feat(aikido-scan): allow disabling Slack notification, add slack-notified output

### DIFF
--- a/aikido-scan/action.sh
+++ b/aikido-scan/action.sh
@@ -13,6 +13,7 @@ parse_args() {
   INPUT_FAIL_ON_DEPENDENCY_SCAN=""
   INPUT_FAIL_ON_MALWARE_SCAN=""
   INPUT_NO_FAIL=""
+  INPUT_NOTIFY_SLACK=""
   INPUT_BOT_TOKEN=""
   INPUT_CHANNEL=""
   INPUT_SERVER_URL=""
@@ -32,6 +33,7 @@ parse_args() {
       --fail-on-dependency-scan)   INPUT_FAIL_ON_DEPENDENCY_SCAN="$2"; shift; shift ;;
       --fail-on-malware-scan)      INPUT_FAIL_ON_MALWARE_SCAN="$2"; shift; shift ;;
       --no-fail)                   INPUT_NO_FAIL="$2"; shift; shift ;;
+      --notify-slack)              INPUT_NOTIFY_SLACK="$2"; shift; shift ;;
       --bot-token)                 INPUT_BOT_TOKEN="$2"; shift; shift ;;
       --channel)                   INPUT_CHANNEL="$2"; shift; shift ;;
       --server-url)                INPUT_SERVER_URL="$2"; shift; shift ;;
@@ -53,21 +55,23 @@ parse_args() {
   if [ "$INPUT_COMMIT_SHA" = "" ]; then
     echo "Parameter 'commit-sha' is empty"; exit 1
   fi
-  if [ "$INPUT_BOT_TOKEN" = "" ]; then
-    echo "Parameter 'bot-token' is empty"; exit 1
-  fi
-  if [ "$INPUT_CHANNEL" = "" ]; then
-    echo "Parameter 'channel' is empty"; exit 1
+  if [ "$INPUT_NOTIFY_SLACK" = "true" ]; then
+    if [ "$INPUT_BOT_TOKEN" = "" ]; then
+      echo "Parameter 'bot-token' is empty"; exit 1
+    fi
+    if [ "$INPUT_CHANNEL" = "" ]; then
+      echo "Parameter 'channel' is empty"; exit 1
+    fi
   fi
   readonly INPUT_APIKEY INPUT_REPOSITORY INPUT_COMMIT_SHA INPUT_MIN_SEVERITY_LEVEL \
     INPUT_FAIL_ON_SAST_SCAN INPUT_FAIL_ON_IAC_SCAN INPUT_FAIL_ON_SECRETS_SCAN \
     INPUT_FAIL_ON_DEPENDENCY_SCAN INPUT_FAIL_ON_MALWARE_SCAN INPUT_NO_FAIL \
-    INPUT_BOT_TOKEN INPUT_CHANNEL INPUT_SERVER_URL INPUT_REPOSITORY_FULL_NAME \
+    INPUT_NOTIFY_SLACK INPUT_BOT_TOKEN INPUT_CHANNEL INPUT_SERVER_URL INPUT_REPOSITORY_FULL_NAME \
     INPUT_BRANCH INPUT_ACTOR INPUT_RUN_ID
   export INPUT_APIKEY INPUT_REPOSITORY INPUT_COMMIT_SHA INPUT_MIN_SEVERITY_LEVEL \
     INPUT_FAIL_ON_SAST_SCAN INPUT_FAIL_ON_IAC_SCAN INPUT_FAIL_ON_SECRETS_SCAN \
     INPUT_FAIL_ON_DEPENDENCY_SCAN INPUT_FAIL_ON_MALWARE_SCAN INPUT_NO_FAIL \
-    INPUT_BOT_TOKEN INPUT_CHANNEL INPUT_SERVER_URL INPUT_REPOSITORY_FULL_NAME \
+    INPUT_NOTIFY_SLACK INPUT_BOT_TOKEN INPUT_CHANNEL INPUT_SERVER_URL INPUT_REPOSITORY_FULL_NAME \
     INPUT_BRANCH INPUT_ACTOR INPUT_RUN_ID
 }
 
@@ -143,20 +147,28 @@ main() {
   diff_url="$(grep -oP 'Diff url: \K\S+' "$log_file" || true)"
   issues="${issues:-0}"
 
+  slack_notified="false"
+  if [ "$scan_exit_code" != "0" ] && [ "$INPUT_NOTIFY_SLACK" = "true" ]; then
+    build_slack_payload "$issues" "$diff_url"
+    post_to_slack
+    slack_notified="true"
+  fi
+
   {
     echo "issues-found=$issues"
     echo "diff-url=$diff_url"
     echo "scan-exit-code=$scan_exit_code"
+    echo "slack-notified=$slack_notified"
   } >> "$GITHUB_OUTPUT"
 
   if [ "$scan_exit_code" != "0" ]; then
-    build_slack_payload "$issues" "$diff_url"
-    post_to_slack
-    {
-      echo "slack-payload<<AIKIDO_SCAN_EOF"
-      echo "$slack_payload"
-      echo "AIKIDO_SCAN_EOF"
-    } >> "$GITHUB_OUTPUT"
+    if [ "$slack_notified" = "true" ]; then
+      {
+        echo "slack-payload<<AIKIDO_SCAN_EOF"
+        echo "$slack_payload"
+        echo "AIKIDO_SCAN_EOF"
+      } >> "$GITHUB_OUTPUT"
+    fi
 
     if [ "$INPUT_NO_FAIL" = "true" ]; then
       echo "Aikido scan found issues (exit code $scan_exit_code), but 'no-fail' is enabled so the action will not fail"

--- a/aikido-scan/action.yml
+++ b/aikido-scan/action.yml
@@ -33,11 +33,17 @@ inputs:
       When set to 'true', the scan still runs and Slack is still notified if issues are
       found, but the action itself exits successfully so CI can continue.
     default: "false"
+  notify-slack:
+    description: |
+      Whether to post a Slack notification when the scan finds issues.
+
+      When set to 'false', 'bot-token' and 'channel' are not required and no
+      notification is sent.
+    default: "true"
   bot-token:
-    description: "A GitHub Actions secret containing a Slack bot user token."
+    description: "A GitHub Actions secret containing a Slack bot user token. Required unless 'notify-slack' is 'false'."
   channel:
-    description: "The Slack channel to notify when the scan finds issues (either a name '#my-channel' or an ID 'CXXXXXXXXXXX')"
-    required: true
+    description: "The Slack channel to notify when the scan finds issues (either a name '#my-channel' or an ID 'CXXXXXXXXXXX'). Required unless 'notify-slack' is 'false'."
 outputs:
   issues-found:
     description: "The number of open issues found by the scan"
@@ -48,6 +54,9 @@ outputs:
   scan-exit-code:
     description: "The exit code returned by the Aikido CI API client"
     value: ${{ steps.scan.outputs.scan-exit-code }}
+  slack-notified:
+    description: "Whether information about the vulnerabilities found was sent to Slack"
+    value: ${{ steps.scan.outputs.slack-notified }}
   slack-payload:
     description: "The JSON payload sent to Slack, if the scan found issues"
     value: ${{ steps.scan.outputs.slack-payload }}
@@ -76,6 +85,7 @@ runs:
         INPUT_FAIL_ON_DEPENDENCY_SCAN: ${{ inputs.fail-on-dependency-scan }}
         INPUT_FAIL_ON_MALWARE_SCAN: ${{ inputs.fail-on-malware-scan }}
         INPUT_NO_FAIL: ${{ inputs.no-fail }}
+        INPUT_NOTIFY_SLACK: ${{ inputs.notify-slack }}
         INPUT_BOT_TOKEN: ${{ inputs.bot-token }}
         INPUT_CHANNEL: ${{ inputs.channel }}
         INPUT_SERVER_URL: ${{ github.server_url }}
@@ -95,6 +105,7 @@ runs:
           --fail-on-dependency-scan "$INPUT_FAIL_ON_DEPENDENCY_SCAN" \
           --fail-on-malware-scan "$INPUT_FAIL_ON_MALWARE_SCAN" \
           --no-fail "$INPUT_NO_FAIL" \
+          --notify-slack "$INPUT_NOTIFY_SLACK" \
           --bot-token "$INPUT_BOT_TOKEN" \
           --channel "$INPUT_CHANNEL" \
           --server-url "$INPUT_SERVER_URL" \


### PR DESCRIPTION
- Add a `notify-slack` input (default `true`) to allow skipping the Slack notification when the scan finds issues; `bot-token`/`channel` are no longer required when it's set to `false`.
- Add a `slack-notified` output so callers can tell whether vulnerability info was actually sent to Slack.
