### PR TITLE
fix(aikido-scan): default to failing only on critical severity issues

### DIFF
--- a/aikido-scan/action.yml
+++ b/aikido-scan/action.yml
@@ -10,7 +10,7 @@ inputs:
       The minimum severity level of an issue that should cause the scan to fail.
 
       Allowed values: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL'
-    default: "HIGH"
+    default: "CRITICAL"
   fail-on-sast-scan:
     description: "Whether the scan should fail if new SAST issues are found"
     default: "true"


### PR DESCRIPTION
The scan previously failed by default on HIGH and above. Change the default min-severity-level to CRITICAL so CI only fails on the most severe findings out of the box.