### PR TITLE
fix(aikido-scan): default no-fail to true

### DIFF
--- a/aikido-scan/action.yml
+++ b/aikido-scan/action.yml
@@ -32,7 +32,7 @@ inputs:
 
       When set to 'true', the scan still runs and Slack is still notified if issues are
       found, but the action itself exits successfully so CI can continue.
-    default: "false"
+    default: "true"
   notify-slack:
     description: |
       Whether to post a Slack notification when the scan finds issues.


### PR DESCRIPTION
Change no-fail to true as a default while we are getting to know Aikido, due to the risk of blocking necessary updates if CI fails due to finding vulnerabilities.